### PR TITLE
Add Full-Credit Voting Mode to MACI

### DIFF
--- a/packages/contracts/contracts/Tally.sol
+++ b/packages/contracts/contracts/Tally.sol
@@ -39,7 +39,7 @@ contract Tally is Clone, SnarkCommon, Hasher, DomainObjs, ITally {
   ///   hashLeftRight(merkle root of the no. of spent voice credits per vote option, salt2)
   /// )
   ///
-  /// Non-QV:
+  /// Non-QV / Full-Credit:
   /// hash2(
   ///   hashLeftRight(merkle root of current results, salt0)
   ///   hashLeftRight(number of spent voice credits, salt1),
@@ -241,7 +241,7 @@ contract Tally is Clone, SnarkCommon, Hasher, DomainObjs, ITally {
   ) public view returns (bool isValid) {
     if (mode == Mode.QV) {
       isValid = verifyQvSpentVoiceCredits(_totalSpent, _totalSpentSalt, _resultCommitment, _perVOSpentVoiceCreditsHash);
-    } else if (mode == Mode.NON_QV) {
+    } else if (mode == Mode.NON_QV || mode == Mode.FULL_CREDIT) {
       isValid = verifyNonQvSpentVoiceCredits(_totalSpent, _totalSpentSalt, _resultCommitment);
     }
   }
@@ -349,7 +349,7 @@ contract Tally is Clone, SnarkCommon, Hasher, DomainObjs, ITally {
       tally[2] = _perVOSpentVoiceCreditsHash;
 
       isValid = hash3(tally) == tallyCommitment;
-    } else if (mode == Mode.NON_QV) {
+    } else if (mode == Mode.NON_QV || mode == Mode.FULL_CREDIT) {
       uint256[2] memory tally;
       tally[0] = hashLeftRight(computedRoot, _tallyResultSalt);
       tally[1] = _spentVoiceCreditsHash;

--- a/packages/contracts/contracts/utilities/DomainObjs.sol
+++ b/packages/contracts/contracts/utilities/DomainObjs.sol
@@ -11,7 +11,8 @@ contract DomainObjs {
   /// @notice voting modes
   enum Mode {
     QV,
-    NON_QV
+    NON_QV,
+    FULL_CREDIT
   }
 
   /// @title Message

--- a/packages/core/ts/utils/errors.ts
+++ b/packages/core/ts/utils/errors.ts
@@ -10,6 +10,7 @@ export enum ProcessMessageErrors {
   InsufficientVoiceCredits = "insufficient voice credits",
   InvalidVoteOptionIndex = "invalid vote option index",
   FailedDecryption = "failed decryption due to either wrong encryption public key or corrupted ciphertext",
+  IncorrectVoteWeightForFullCredit = "Vote weight must equal full available balance in FULL_CREDIT mode",
 }
 
 /**


### PR DESCRIPTION
### Description:
This PR implements the full-credit voting mode as described in the issue. The new mode restricts voters to spend their entire available credits on a single option, while still allowing them to override their votes multiple times.
### Changes:
- Added `FULL_CREDIT` to the Mode enum in `DomainObjs.sol`.
- Updated `Tally.sol` to recognize and process the `FULL_CREDIT` mode, aligning its verification logic with `NON_QV`.
- Introduced VotingMode constants in `Poll.ts` and added a mode property to the Poll class.
- Modified the processMessage function in `Poll.ts` to enforce full-credit voting rules.
- Added IncorrectVoteWeightForFullCredit to ProcessMessageErrors in `errors.ts`.
### Implementation Details:
The implementation ensures that the full-credit mode is integrated into both the on-chain and off-chain logic. The processMessage function checks that the vote weight equals the full available balance, setting the remaining balance to zero if valid.
### Related Issue:
#2314